### PR TITLE
Resolve a panic for a '-file' flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ func _main() error {
 	var dockerFile string
 	flag.BoolVar(&verbose, "v", false, "verbose mode: show ignored files on stderr")
 	flag.StringVar(&dockerFile, "f", "", "name of the `Dockerfile`")
-	flag.StringVar(&dockerFile, "-file", "", "name of the `Dockerfile`")
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "usage: %s [-v] [PATH]\n\n", os.Args[0])
 		flag.CommandLine.PrintDefaults()


### PR DESCRIPTION
Instructions did not mention a long flag, so it was simply removed.

Full panic message:

```
flag "-file" begins with -
panic: flag "-file" begins with -

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc000122120, {0x11059d0, 0xc00010a370}, {0x10e0a70, 0x1}, {0x10e4419, 0x18})
	/usr/local/Cellar/go/1.17/libexec/src/flag/flag.go:864 +0x439
flag.StringVar(...)
	/usr/local/Cellar/go/1.17/libexec/src/flag/flag.go:768
main._main()
	/Users/ezandbe/go/pkg/mod/github.com/dolmen-go/docker-list-context@v0.0.0-20210426215619-0cef44892096/main.go:42 +0x14a
main.main()
	/Users/ezandbe/go/pkg/mod/github.com/dolmen-go/docker-list-context@v0.0.0-20210426215619-0cef44892096/main.go:30 +0x19
```

Closes #1 