### PR TITLE
Fix matches and remove unnecessary buildkit dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/dolmen-go/docker-list-context
 
 go 1.23.1
 
-require (
-	github.com/moby/buildkit v0.15.2
-	github.com/moby/patternmatcher v0.6.0
-)
+require github.com/moby/patternmatcher v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/dolmen-go/docker-list-context
 
-go 1.21
-
-toolchain go1.22.3
+go 1.23.1
 
 require (
-	github.com/moby/buildkit v0.13.2
+	github.com/moby/buildkit v0.15.2
 	github.com/moby/patternmatcher v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/moby/buildkit v0.15.2 h1:DnONr0AoceTWyv+plsQ7IhkSaj+6o0WyoaxYPyTFIxs=
-github.com/moby/buildkit v0.15.2/go.mod h1:Yis8ZMUJTHX9XhH9zVyK2igqSHV3sxi3UN0uztZocZk=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/moby/buildkit v0.13.2 h1:nXNszM4qD9E7QtG7bFWPnDI1teUQFQglBzon/IU3SzI=
-github.com/moby/buildkit v0.13.2/go.mod h1:2cyVOv9NoHM7arphK9ZfHIWKn9YVZRFd1wXB8kKmEzY=
+github.com/moby/buildkit v0.15.2 h1:DnONr0AoceTWyv+plsQ7IhkSaj+6o0WyoaxYPyTFIxs=
+github.com/moby/buildkit v0.15.2/go.mod h1:Yis8ZMUJTHX9XhH9zVyK2igqSHV3sxi3UN0uztZocZk=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	"github.com/moby/patternmatcher"
+	"github.com/moby/patternmatcher/ignorefile"
 )
 
 func main() {
@@ -78,7 +78,7 @@ func _main() error {
 	// https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.1.0
 	for _, dockerIgnore = range []string{dockerFile + ".dockerignore", ".dockerignore"} {
 		if f, err := os.Open(dockerIgnore); err == nil {
-			if ignorePatterns, err = dockerignore.ReadAll(f); err != nil {
+			if ignorePatterns, err = ignorefile.ReadAll(f); err != nil {
 				return fmt.Errorf(dockerIgnore+": %w", err)
 			}
 			break

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func _main() error {
 		if err != nil {
 			return nil
 		}
-		if m, _ := ignore.Matches(relFilePath); m {
+		if m, _ := ignore.MatchesOrParentMatches(relFilePath); m {
 			if verbose {
 				fmt.Fprintln(os.Stderr, "IGNORE", relFilePath)
 			}


### PR DESCRIPTION
https://pkg.go.dev/github.com/moby/patternmatcher@v0.6.0#PatternMatcher.Matches

> Deprecated: This implementation is buggy (it only checks a single parent dir against the pattern) and will be removed soon. Use either MatchesOrParentMatches or MatchesUsingParentResults instead. 

https://pkg.go.dev/github.com/moby/buildkit@v0.15.2/frontend/dockerfile/dockerignore#ReadAll

> Deprecated: use ignorefile.ReadAll

- go: 1.21 => 1.23.1